### PR TITLE
Consistency for application secret

### DIFF
--- a/Shoot/README.md
+++ b/Shoot/README.md
@@ -80,10 +80,8 @@ In AppDelegate.swift, add the callback method ```application:openURL:sourceAppli
 
 In [1], we retrieve the url information containing authz code. To inform OAuth2 lib to carry on the OAuth2 dance post a notification in [2].
 
-## Google setup (optional)
+## Google setup
 Here is the links and detailed setup instructions for Google Drive however as I noticed it is quite poorly documented for iOS app.
-
-NOTES: This step is optional if your want to try the GoogleDrive app out of the box. The client id for 'GoogleDrive' has already been generated and [is available in the app](https://github.com/aerogear/aerogear-ios-cookbook/blob/1.6.x/GoogleDrive/GoogleDrive/AGViewController.m#L156). However if you want to create your own app, you will have to go through your provider setup instruction. Here's how to do it for Google Drive.
 
 1. Have a Google account
 2. Go to [Google cloud console](https://cloud.google.com/console#/project), create a new project

--- a/Shoot/Shoot/ViewController.swift
+++ b/Shoot/Shoot/ViewController.swift
@@ -138,7 +138,7 @@ class ViewController: UIViewController, UIImagePickerControllerDelegate, UINavig
         println("Perform photo upload with Google")
 
         let googleConfig = GoogleConfig(
-            clientId: "873670803862-g6pjsgt64gvp7r25edgf4154e8sld5nq.apps.googleusercontent.com",
+            clientId: "<your client secret goes here.apps.googleusercontent.com>",
             scopes:["https://www.googleapis.com/auth/drive"])
 
         let gdModule = AccountManager.addGoogleAccount(googleConfig)


### PR DESCRIPTION
I don't think its necessary to expose personal application ID.

The goal of this PR is to keep the consistency across our examples: https://github.com/aerogear/aerogear-cordova-cookbook/pull/11