### PR TITLE
Adding sync server path configuration option.

### DIFF
--- a/Jedi/DiffMatchPatchSync/AeroGearSyncDemo/Info.plist
+++ b/Jedi/DiffMatchPatchSync/AeroGearSyncDemo/Info.plist
@@ -6,6 +6,8 @@
 	<string>localhost</string>
 	<key>SyncServerPort</key>
 	<integer>7777</integer>
+	<key>SyncServerPath</key>
+	<string>/sync</string>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleExecutable</key>

--- a/Jedi/DiffMatchPatchSync/AeroGearSyncDemo/ViewController.swift
+++ b/Jedi/DiffMatchPatchSync/AeroGearSyncDemo/ViewController.swift
@@ -65,8 +65,9 @@ class ViewController: UIViewController, UITextFieldDelegate {
 
         let syncServerHost = NSBundle.mainBundle().objectForInfoDictionaryKey("SyncServerHost")! as String
         let syncServerPort = NSBundle.mainBundle().objectForInfoDictionaryKey("SyncServerPort")! as Int
+        let syncServerPath = NSBundle.mainBundle().objectForInfoDictionaryKey("SyncServerPath")! as String
         let engine = ClientSyncEngine(synchronizer: DiffMatchPatchSynchronizer(), dataStore: InMemoryDataStore())
-        syncClient = SyncClient(url: "ws://\(syncServerHost):\(syncServerPort)", syncEngine: engine)
+        syncClient = SyncClient(url: "ws://\(syncServerHost):\(syncServerPort)\(syncServerPath)", syncEngine: engine)
         connect()
     }
     

--- a/Jedi/JsonPatchSync/AeroGearSyncDemo/Info.plist
+++ b/Jedi/JsonPatchSync/AeroGearSyncDemo/Info.plist
@@ -6,6 +6,8 @@
 	<string>localhost</string>
 	<key>SyncServerPort</key>
 	<integer>7777</integer>
+	<key>SyncServerPath</key>
+	<string>/sync</string>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleExecutable</key>

--- a/Jedi/JsonPatchSync/AeroGearSyncDemo/ViewController.swift
+++ b/Jedi/JsonPatchSync/AeroGearSyncDemo/ViewController.swift
@@ -56,8 +56,9 @@ class ViewController: UIViewController, UITextFieldDelegate {
 
         let syncServerHost = NSBundle.mainBundle().objectForInfoDictionaryKey("SyncServerHost")! as String
         let syncServerPort = NSBundle.mainBundle().objectForInfoDictionaryKey("SyncServerPort")! as Int
+        let syncPath = NSBundle.mainBundle().objectForInfoDictionaryKey("SyncServerPath")! as String
         let engine = ClientSyncEngine(synchronizer: JsonPatchSynchronizer(), dataStore: InMemoryDataStore())
-        syncClient = SyncClient(url: "ws://\(syncServerHost):\(syncServerPort)", syncEngine: engine)
+        syncClient = SyncClient(url: "ws://\(syncServerHost):\(syncServerPort)\(syncPath)", syncEngine: engine)
         connect()
         println("ClientId=\(clientId)")
     }


### PR DESCRIPTION
Motivation:
When the client connects is currently not specifying a path to connect
to. This works fine with the Netty server but not with WildFly which
will fail the WebSocket connection attempt.

Modifications:
This commit adds a 'SyncServerPath' property which defaults to `/sync`.

For testing please use  [server-wildfly](https://github.com/danbev/aerogear-sync-server/tree/wildfly-updates) module which contains a few "fixes" that are not yet in summers branch.