### PR TITLE
remove custom repo

### DIFF
--- a/Jedi/DiffMatchPatchSync/Podfile
+++ b/Jedi/DiffMatchPatchSync/Podfile
@@ -1,4 +1,3 @@
-source 'https://github.com/aerogear/Cocoapods-repo.git'
 source 'https://github.com/CocoaPods/Specs.git'
 
 xcodeproj 'AeroGearSyncDemo.xcodeproj'

--- a/Jedi/JsonPatchSync/Podfile
+++ b/Jedi/JsonPatchSync/Podfile
@@ -1,4 +1,3 @@
-source 'https://github.com/aerogear/Cocoapods-repo.git'
 source 'https://github.com/CocoaPods/Specs.git'
 
 xcodeproj 'AeroGearSyncDemo.xcodeproj'


### PR DESCRIPTION
Motivation
after [PR#19](https://github.com/aerogear/aerogear-ios-sync/pull/19) is merged, this update the demo Podfile's to remove the custom defined repo

@corinnekrych mind to look and merge